### PR TITLE
Sort view connections before comparing

### DIFF
--- a/controllers/humioview_controller.go
+++ b/controllers/humioview_controller.go
@@ -19,17 +19,19 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"sort"
+	"time"
+
 	"github.com/go-logr/logr"
 	humioapi "github.com/humio/cli/api"
 	"github.com/humio/humio-operator/pkg/helpers"
 	"github.com/humio/humio-operator/pkg/humio"
 	"github.com/humio/humio-operator/pkg/kubernetes"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"reflect"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"time"
 
 	humiov1alpha1 "github.com/humio/humio-operator/api/v1alpha1"
 )
@@ -160,7 +162,7 @@ func (r *HumioViewReconciler) reconcileHumioView(ctx context.Context, config *hu
 	}
 
 	// Update
-	if reflect.DeepEqual(curView.Connections, hv.GetViewConnections()) == false {
+	if viewConnectionsDiffer(curView.Connections, hv.GetViewConnections()) {
 		r.Log.Info(fmt.Sprintf("view information differs, triggering update, expected %v, got: %v",
 			hv.Spec.Connections,
 			curView.Connections))
@@ -173,6 +175,27 @@ func (r *HumioViewReconciler) reconcileHumioView(ctx context.Context, config *hu
 
 	r.Log.Info("done reconciling, will requeue after 15 seconds")
 	return reconcile.Result{Requeue: true, RequeueAfter: time.Second * 15}, nil
+}
+
+// viewConnectionsDiffer returns whether two slices of connections differ.
+// Connections are compared by repo name and filter so the ordering is not taken
+// into account.
+func viewConnectionsDiffer(curConnections, newConnections []humioapi.ViewConnection) bool {
+	// sort the slices to avoid changes to the order of items in the slice to
+	// trigger an update. Kubernetes does not guarantee that slice items are
+	// deterministic ordered, so without this we could trigger updates to views
+	// without any functional changes. As the result of a view update in Humio is
+	// live queries against it are refreshed it can lead to dashboards and queries
+	// refreshing all the time.
+	sortConnections(curConnections)
+	sortConnections(newConnections)
+	return !reflect.DeepEqual(curConnections, newConnections)
+}
+
+func sortConnections(connections []humioapi.ViewConnection) {
+	sort.SliceStable(connections, func(i, j int) bool {
+		return connections[i].RepoName > connections[j].RepoName || connections[i].Filter > connections[j].Filter
+	})
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/controllers/humioview_controller_test.go
+++ b/controllers/humioview_controller_test.go
@@ -1,0 +1,122 @@
+package controllers
+
+import (
+	"testing"
+
+	humioapi "github.com/humio/cli/api"
+)
+
+func TestViewConnectionsDiffer(t *testing.T) {
+	tt := []struct {
+		name         string
+		current, new []humioapi.ViewConnection
+		differ       bool
+	}{
+		{
+			name:    "nil connections",
+			current: nil,
+			new:     nil,
+			differ:  false,
+		},
+		{
+			name:    "empty slices",
+			current: []humioapi.ViewConnection{},
+			new:     []humioapi.ViewConnection{},
+			differ:  false,
+		},
+		{
+			name:    "new connection added",
+			current: []humioapi.ViewConnection{},
+			new: []humioapi.ViewConnection{
+				{
+					RepoName: "repo",
+					Filter:   "*",
+				},
+			},
+			differ: true,
+		},
+		{
+			name: "update filter",
+			current: []humioapi.ViewConnection{
+				{
+					RepoName: "repo",
+					Filter:   "*",
+				},
+			},
+			new: []humioapi.ViewConnection{
+				{
+					RepoName: "repo",
+					Filter:   "* more=",
+				},
+			},
+			differ: true,
+		},
+		{
+			name: "remove connection",
+			current: []humioapi.ViewConnection{
+				{
+					RepoName: "repo",
+					Filter:   "*",
+				},
+			},
+			new:    []humioapi.ViewConnection{},
+			differ: true,
+		},
+		{
+			name: "reorder connections where name differs",
+			current: []humioapi.ViewConnection{
+				{
+					RepoName: "repo-a",
+					Filter:   "*",
+				},
+				{
+					RepoName: "repo-b",
+					Filter:   "*",
+				},
+			},
+			new: []humioapi.ViewConnection{
+				{
+					RepoName: "repo-b",
+					Filter:   "*",
+				},
+				{
+					RepoName: "repo-a",
+					Filter:   "*",
+				},
+			},
+			differ: false,
+		},
+		{
+			name: "reorder connections where filter differs",
+			current: []humioapi.ViewConnection{
+				{
+					RepoName: "repo",
+					Filter:   "a=*",
+				},
+				{
+					RepoName: "repo",
+					Filter:   "b=*",
+				},
+			},
+			new: []humioapi.ViewConnection{
+				{
+					RepoName: "repo",
+					Filter:   "b=*",
+				},
+				{
+					RepoName: "repo",
+					Filter:   "a=*",
+				},
+			},
+			differ: false,
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			result := viewConnectionsDiffer(tc.current, tc.new)
+			if result != tc.differ {
+				t.Errorf("viewConnectionsDiffer() got = %v, want %v", result, tc.differ)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Currently if a view has multiple connections Kubernetes might return the
connection slice in different orders every time. As we compare view connections
with a reflect.DeepEqual that results in updates to views over and over again.
When ever a view is updated in Humio any live queries are refreshed which leads
to flashing dashboards.

This change introduces a mitigation to this behaviour by sorting the existing
and new connection slices before comparing them. This way we only update the
view in Humio if the functional behaviour has changed.